### PR TITLE
don't always set ace/mode/coffee

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -2803,7 +2803,7 @@ define ['droplet-helper',
 
     @aceEditor.setTheme 'ace/theme/chrome'
     @aceEditor.setFontSize 15
-    @aceEditor.getSession().setMode 'ace/mode/coffee'
+    @aceEditor.getSession().setMode 'ace/mode/' + @options.mode
     @aceEditor.getSession().setTabSize 2
 
     @aceEditor.on 'change', =>


### PR DESCRIPTION
ace editor was not being set to ace/mode/javascript when droplet was initialized in javascript mode.

please verify that this works properly in mode/coffee as I don't have a good way to verify for sure.

also, I don't know if this will also handle dynamic calls to droplet's setMode.