### PR TITLE
Add support for dotted methods in Javascript and Coffeescript

### DIFF
--- a/src/javascript.coffee
+++ b/src/javascript.coffee
@@ -204,8 +204,8 @@ define ['droplet-helper', 'droplet-model', 'droplet-parser', 'acorn'], (helper, 
       obj = node.callee
       props = []
       while obj.type is 'MemberExpression'
-        props.unshift node.property.name
-        obj = node.object
+        props.unshift obj.property.name
+        obj = obj.object
       if obj.type is 'Identifier'
         props.unshift obj.name
       else
@@ -213,7 +213,7 @@ define ['droplet-helper', 'droplet-model', 'droplet-parser', 'acorn'], (helper, 
       props
 
     functionMatchesList: (node, list) ->
-      fname = fullFunctionNameArray node
+      fname = @fullFunctionNameArray node
       return (fname[fname.length - 1] in list) or
              (fname.length > 1 and fname.join('.') in list)
 

--- a/test/coffee/parserTests.coffee
+++ b/test/coffee/parserTests.coffee
@@ -21,7 +21,7 @@ describe 'Parser unity', (done) ->
     it 'should round-trip ' + str.split('\n')[0] +
         (if str.split('\n').length > 1 then '...' else ''), ->
       assert.equal str, coffee.parse(str, wrapAtRoot: true).stringify()
-
+  testString '/// #{x} ///'
   testString 'fd 10'
   testString 'fd 10 + 10'
   testString 'console.log 10 + 10'
@@ -45,7 +45,6 @@ describe 'Parser unity', (done) ->
       see key is value
       see array[n]
   '''
-
   testFile = (name) ->
     it "should round-trip on #{name}", ->
       file = fs.readFileSync(name).toString()

--- a/test/coffee/tests.coffee
+++ b/test/coffee/tests.coffee
@@ -88,6 +88,132 @@ require ['droplet-helper', 'droplet-model', 'droplet-parser', 'droplet-coffee', 
       'Custom known functions work'
     )
 
+  test 'Dotted methods', ->
+    customCoffee = new Coffee {
+      blockFunctions: ['console.log', 'speak']
+      valueFunctions: ['Math.log', 'log']
+      eitherFunctions: ['setTimeout']
+    }
+
+    customSerialization = customCoffee.parse('''
+    console.log Math.log log x.log log
+    ''').serialize()
+
+    expectedSerialization = '''
+      <segment
+        isLassoSegment="false"
+      ><block
+        precedence="0"
+        color="command"
+        socketLevel="0"
+        classes="Call works-as-method-call mostly-block"
+      >console.log <socket
+        precedence="-1"
+        handwritten="false"
+        classes="Call works-as-method-call"
+      ><block
+        precedence="0"
+        color="value"
+        socketLevel="0"
+        classes="Call works-as-method-call mostly-value"
+      >Math.log <socket
+        precedence="-1"
+        handwritten="false"
+        classes="Call works-as-method-call"
+      ><block
+        precedence="0"
+        color="value"
+        socketLevel="0"
+        classes="Call works-as-method-call mostly-value"
+      >log <socket
+        precedence="-1"
+        handwritten="false"
+        classes="Call works-as-method-call"
+      ><block
+        precedence="0"
+        color="value"
+        socketLevel="0"
+        classes="Call works-as-method-call mostly-value"
+      ><socket
+        precedence="0"
+        handwritten="false"
+        classes="Literal"
+      >x</socket
+      >.log <socket
+        precedence="-1"
+        handwritten="false"
+        classes="Value"
+      >log</socket
+      ></block></socket></block></socket></block></socket></block></segment>
+    '''
+    strictEqual(
+      helper.xmlPrettyPrint(customSerialization),
+      helper.xmlPrettyPrint(expectedSerialization),
+      'Dotted known functions work'
+    )
+
+  test 'JS dotted methods', ->
+    customJS = new JavaScript {
+      blockFunctions: ['console.log', 'speak']
+      valueFunctions: ['Math.log', 'log']
+      eitherFunctions: ['setTimeout']
+    }
+
+    customSerialization = customJS.parse('''
+    console.log(Math.log(log(x.log(log))));
+    ''').serialize()
+
+    expectedSerialization = '''
+      <segment
+        isLassoSegment="false"
+      ><block
+        precedence="2"
+        color="blank"
+        socketLevel="0"
+        classes="CallExpression mostly-block"
+      >console.log(<socket
+        precedence="100"
+        handwritten="false"
+        classes=""
+      ><block
+        precedence="2"
+        color="blank"
+        socketLevel="0"
+        classes="CallExpression mostly-value"
+      >Math.log(<socket
+        precedence="100"
+        handwritten="false"
+        classes=""
+      ><block
+        precedence="2"
+        color="value"
+        socketLevel="0"
+        classes="CallExpression mostly-value"
+      >log(<socket
+        precedence="100"
+        handwritten="false"
+        classes=""
+      ><block
+        precedence="2"
+        color="blank"
+        socketLevel="0"
+        classes="CallExpression mostly-value"
+      >x.log(<socket
+        precedence="100"
+        handwritten="false"
+        classes=""
+      >log</socket
+      >)</block></socket
+      >)</block></socket
+      >)</block></socket
+      >);</block></segment>
+    '''
+    strictEqual(
+      helper.xmlPrettyPrint(customSerialization),
+      helper.xmlPrettyPrint(expectedSerialization),
+      'Dotted known functions work'
+    )
+
   test 'XML parser unity', ->
     q = new XMLHttpRequest()
     q.open 'GET', '/test/data/parserSuccess.json', false

--- a/test/coffee/tests.coffee
+++ b/test/coffee/tests.coffee
@@ -35,51 +35,51 @@ require ['droplet-helper', 'droplet-model', 'droplet-parser', 'droplet-coffee', 
     ''').serialize()
 
     expectedSerialization = '''
-<segment
-  isLassoSegment=\"false\"><block
-  precedence=\"0\"
-  color=\"command\"
-  socketLevel=\"0\"
-  classes=\"Call works-as-method-call mostly-block\">marius <socket
-  precedence=\"-1\"
-  handwritten=\"false\"
-  classes=\"Call works-as-method-call\"><block
-  precedence=\"0\"
-  color=\"value\"
-  socketLevel=\"0\"
-  classes=\"Call works-as-method-call mostly-value\">eponine <socket
-  precedence=\"-1\"
-  handwritten=\"false\"
-  classes=\"Value\">10</socket></block></socket></block>
-<block
-  precedence=\"0\"
-  color=\"command\"
-  socketLevel=\"0\"
-  classes=\"Call works-as-method-call any-drop\"><socket
-  precedence=\"0\"
-  handwritten=\"false\"
-  classes=\"Value\">fd</socket> <socket
-  precedence=\"-1\"
-  handwritten=\"false\"
-  classes=\"Call works-as-method-call\"><block
-  precedence=\"0\"
-  color=\"command\"
-  socketLevel=\"0\"
-  classes=\"Call works-as-method-call any-drop\"><socket
-  precedence=\"0\"
-  handwritten=\"false\"
-  classes=\"Value\">random</socket> <socket
-  precedence=\"-1\"
-  handwritten=\"false\"
-  classes=\"Value\">100</socket></block></socket></block>
-<block
-  precedence=\"0\"
-  color=\"command\"
-  socketLevel=\"0\"
-  classes=\"Call works-as-method-call any-drop\">cosette <socket
-  precedence=\"-1\"
-  handwritten=\"false\"
-  classes=\"Value\">20</socket></block></segment>
+      <segment
+        isLassoSegment="false"><block
+        precedence="0"
+        color="command"
+        socketLevel="0"
+        classes="Call works-as-method-call mostly-block">marius <socket
+        precedence="-1"
+        handwritten="false"
+        classes="Call works-as-method-call"><block
+        precedence="0"
+        color="value"
+        socketLevel="0"
+        classes="Call works-as-method-call mostly-value">eponine <socket
+        precedence="-1"
+        handwritten="false"
+        classes="Value">10</socket></block></socket></block>
+      <block
+        precedence="0"
+        color="command"
+        socketLevel="0"
+        classes="Call works-as-method-call any-drop"><socket
+        precedence="0"
+        handwritten="false"
+        classes="Value">fd</socket> <socket
+        precedence="-1"
+        handwritten="false"
+        classes="Call works-as-method-call"><block
+        precedence="0"
+        color="command"
+        socketLevel="0"
+        classes="Call works-as-method-call any-drop"><socket
+        precedence="0"
+        handwritten="false"
+        classes="Value">random</socket> <socket
+        precedence="-1"
+        handwritten="false"
+        classes="Value">100</socket></block></socket></block>
+      <block
+        precedence="0"
+        color="command"
+        socketLevel="0"
+        classes="Call works-as-method-call any-drop">cosette <socket
+        precedence="-1"
+        handwritten="false"
+        classes="Value">20</socket></block></segment>
     '''
 
     strictEqual(


### PR DESCRIPTION
Dotted methods can now be listed in function whitelists; if a fully-qualified function name such as "Math.round" matches a dotted name, the function name is treated as a single (non-editable) block.