### PR TITLE
Coffeescript: merge inline code definition blocks.

### DIFF
--- a/test/coffee/tests.coffee
+++ b/test/coffee/tests.coffee
@@ -29,9 +29,9 @@ require ['droplet-helper', 'droplet-model', 'droplet-parser', 'droplet-coffee', 
     }
 
     window.customSerialization = customSerialization = customCoffee.parse('''
-    marius eponine 10
-    fd random 100
-    cosette 20
+      marius eponine 10
+      fd random 100
+      cosette 20
     ''').serialize()
 
     expectedSerialization = '''
@@ -96,7 +96,7 @@ require ['droplet-helper', 'droplet-model', 'droplet-parser', 'droplet-coffee', 
     }
 
     customSerialization = customCoffee.parse('''
-    console.log Math.log log x.log log
+      console.log Math.log log x.log log
     ''').serialize()
 
     expectedSerialization = '''
@@ -160,7 +160,7 @@ require ['droplet-helper', 'droplet-model', 'droplet-parser', 'droplet-coffee', 
     }
 
     customSerialization = customJS.parse('''
-    console.log(Math.log(log(x.log(log))));
+      console.log(Math.log(log(x.log(log))));
     ''').serialize()
 
     expectedSerialization = '''
@@ -207,6 +207,82 @@ require ['droplet-helper', 'droplet-model', 'droplet-parser', 'droplet-coffee', 
       >)</block></socket
       >)</block></socket
       >);</block></segment>
+    '''
+    strictEqual(
+      helper.xmlPrettyPrint(customSerialization),
+      helper.xmlPrettyPrint(expectedSerialization),
+      'Dotted known functions work'
+    )
+
+  test 'Merged code blocks', ->
+    coffee = new Coffee
+    customSerialization = coffee.parse('''
+      x = (y) -> y * y
+      button 'clickme', ->
+        write 'ouch'
+    ''').serialize()
+
+    expectedSerialization = '''
+      <segment
+        isLassoSegment="false"
+      ><block
+        precedence="0"
+        color="command"
+        socketLevel="0"
+        classes="Assign mostly-block"
+      ><socket
+        precedence="0"
+        handwritten="false"
+        classes="Value lvalue"
+      >x</socket
+      > = (<socket
+        precedence="0"
+        handwritten="false"
+        classes="Param forbid-all"
+      >y</socket
+      >) -&gt; <socket
+        precedence="0"
+        handwritten="false"
+        classes="Block"
+      ><block
+        precedence="5"
+        color="value"
+        socketLevel="0"
+        classes="Op value-only"
+      ><socket
+        precedence="5"
+        handwritten="false"
+        classes="Value"
+      >y</socket
+      > * <socket
+        precedence="5"
+        handwritten="false"
+        classes="Value"
+      >y</socket></block></socket></block>
+      <block
+        precedence="0"
+        color="command"
+        socketLevel="0"
+        classes="Call works-as-method-call any-drop"
+      >button <socket
+        precedence="0"
+        handwritten="false"
+        classes="Value"
+      >'clickme'</socket
+      >, -&gt;<indent
+        prefix="  "
+        classes=""
+      >
+      <block
+        precedence="0"
+        color="command"
+        socketLevel="0"
+        classes="Call works-as-method-call any-drop"
+      >write <socket
+        precedence="-1"
+        handwritten="false"
+        classes="Value"
+      >'ouch'</socket></block></indent></block></segment>
     '''
     strictEqual(
       helper.xmlPrettyPrint(customSerialization),


### PR DESCRIPTION
This change (requested by CS First instructors)
avoids treating inline lambda (->) functions as
separate blocks in Coffeescript in two cases:

(1) direct assignment of a lambda

assignable = (x) -> dosomething

Instead of treating the = and the -> as separate blocks, these are
treated as a single block.

(2) use of a lambda as the last argument of a function call

button 'clickme', ->
  dosomething

Instead of treating the function call (button(..)) as a separate
block from the ->, these are treated as a single block.

This is implemented by factoring the handling of a -> code block
into an @addCode method, and separating the socket handling from
the delineation of the block for the ->.  @addCode is called
by the Assign handler when the RHS is a Code node and by the
Call handler with the last arg is a Code node.

Other Code nodes still get their own block, so, for example,
putting the code in parentheses will split it into its own block.