### PR TITLE
Support UnaryExpression nodes like !() in Javascript.

### DIFF
--- a/src/javascript.coffee
+++ b/src/javascript.coffee
@@ -116,6 +116,7 @@ define ['droplet-helper', 'droplet-model', 'droplet-parser', 'acorn'], (helper, 
 
   COLORS = {
     'BinaryExpression': 'value'
+    'UnaryExpression': 'value'
     'FunctionExpression': 'value'
     'FunctionDeclaration': 'violet'
     'AssignmentExpression': 'command'
@@ -241,6 +242,8 @@ define ['droplet-helper', 'droplet-model', 'droplet-parser', 'acorn'], (helper, 
         when 'BinaryExpression'
           return OPERATOR_PRECEDENCES[node.operator]
         when 'AssignStatement'
+          return 17
+        when 'UnaryExpression'
           return 17
         when 'CallExpression'
           return 2
@@ -416,6 +419,9 @@ define ['droplet-helper', 'droplet-model', 'droplet-parser', 'acorn'], (helper, 
           @jsBlock node, depth, bounds
           @jsSocketAndMark indentDepth, node.left, depth + 1, OPERATOR_PRECEDENCES[node.operator]
           @jsSocketAndMark indentDepth, node.right, depth + 1, OPERATOR_PRECEDENCES[node.operator]
+        when 'UnaryExpression'
+          @jsBlock node, depth, bounds
+          @jsSocketAndMark indentDepth, node.argument, depth + 1, 17
         when 'ExpressionStatement'
           @mark indentDepth, node.expression, depth + 1, @getBounds node
         when 'Identifier'

--- a/test/coffee/tests.coffee
+++ b/test/coffee/tests.coffee
@@ -203,12 +203,12 @@ require ['droplet-helper', 'droplet-model', 'droplet-parser', 'droplet-coffee', 
         handwritten="false"
         classes=""
       ><block
-        precedence="17"
+        precedence="4"
         color="value"
         socketLevel="0"
         classes="UnaryExpression mostly-value"
       >~<socket
-        precedence="17"
+        precedence="4"
         handwritten="false"
         classes=""
       >log</socket></block></socket

--- a/test/coffee/tests.coffee
+++ b/test/coffee/tests.coffee
@@ -160,7 +160,7 @@ require ['droplet-helper', 'droplet-model', 'droplet-parser', 'droplet-coffee', 
     }
 
     customSerialization = customJS.parse('''
-      console.log(Math.log(log(x.log(log))));
+      console.log(Math.log(log(x.log(~log))));
     ''').serialize()
 
     expectedSerialization = '''
@@ -202,7 +202,16 @@ require ['droplet-helper', 'droplet-model', 'droplet-parser', 'droplet-coffee', 
         precedence="100"
         handwritten="false"
         classes=""
-      >log</socket
+      ><block
+        precedence="17"
+        color="value"
+        socketLevel="0"
+        classes="UnaryExpression mostly-value"
+      >~<socket
+        precedence="17"
+        handwritten="false"
+        classes=""
+      >log</socket></block></socket
       >)</block></socket
       >)</block></socket
       >)</block></socket


### PR DESCRIPTION
This change adds support for (value-colored) blocks that come from
Javascript UnaryExpressions such as ~() and !().  Previously these
nodes were unhandled, so would just be greated as unblockified
plain text areas.