### PR TITLE
Allow return ouside function in JS.

### DIFF
--- a/src/javascript.coffee
+++ b/src/javascript.coffee
@@ -196,6 +196,7 @@ define ['droplet-helper', 'droplet-model', 'droplet-parser', 'acorn'], (helper, 
       tree = acorn.parse(@text, {
         locations: true
         line: 0
+        allowReturnOutsideFunction: true
       })
 
       #console.log 'PROGRAM IS', JSON.stringify tree, null, 2


### PR DESCRIPTION
Previously "return __" could not be parsed as part of the palette
because a top-level return is not allowed in the ECMAScript 5 spec.
It's a slightly odd rule because it adds context-dependence.
While most JS code looks the same everywhere, top-level code actually
has slightly different syntax - because return is not alllowed.

It's easier for the block editor to avoid this asymmetry and allow
return everywhere, at least from the point of view of parsing
blocks.  It turns out this is an issue that has been seen by other
tools, and that acorn has an option that lets us break this rule.

This change sets the allowReturnOutsideFunction option for acorn.