### PR TITLE
Resize canvases properly

### DIFF
--- a/css/droplet.css
+++ b/css/droplet.css
@@ -68,7 +68,7 @@
   position: absolute;
   top: 0; bottom: 0; width: 300px;
   max-width: 40%;
-  overflow: hidden;
+  overflow: visible;
   z-index: 257;
   -webkit-user-select: none;
   -khtml-user-select: none;

--- a/css/droplet.css
+++ b/css/droplet.css
@@ -45,6 +45,7 @@
   -ms-user-select: none;
   user-select: none;
   overflow: hidden;
+  outline: none;
 }
 .droplet-ace {
   position: absolute;

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -908,10 +908,10 @@ define ['droplet-helper',
     @dragCanvas.width = 0
     @dragCanvas.height = 0
 
-    @highlightCanvas.width = @dropletElement.offsetWidth
+    @highlightCanvas.width = @dropletElement.offsetWidth - @gutterElement.offsetWidth
     @highlightCanvas.style.width = "#{@highlightCanvas.width}px"
 
-    @highlightCanvas.height = @dropletElement.offsetHeight
+    @highlightCanvas.height = @dropletElement.offsetHeight - @gutterElement.offsetWidth
     @highlightCanvas.style.height = "#{@highlightCanvas.height}px"
 
     @highlightCanvas.style.left = "#{@mainCanvas.offsetLeft}px"
@@ -2161,10 +2161,10 @@ define ['droplet-helper',
   # Deal with resize for the lasso
   # select canvas
   Editor::resizeLassoCanvas = ->
-    @lassoSelectCanvas.width = @dropletElement.offsetWidth
+    @lassoSelectCanvas.width = @dropletElement.offsetWidth - @gutterElement.offsetWidth
     @lassoSelectCanvas.style.width = "#{@lassoSelectCanvas.width}px"
 
-    @lassoSelectCanvas.height = @dropletElement.offsetHeight
+    @lassoSelectCanvas.height = @dropletElement.offsetHeight - @gutterElement.offsetWidth
     @lassoSelectCanvas.style.height = "#{@lassoSelectCanvas.height}px"
 
     @lassoSelectCanvas.style.left = "#{@mainCanvas.offsetLeft}px"
@@ -3810,10 +3810,10 @@ define ['droplet-helper',
     @dropletElement.appendChild @cursorCanvas
 
   Editor::resizeCursorCanvas = ->
-    @cursorCanvas.width = @dropletElement.offsetWidth
+    @cursorCanvas.width = @dropletElement.offsetWidth - @gutterElement.offsetWidth
     @cursorCanvas.style.width = "#{@cursorCanvas.width}px"
 
-    @cursorCanvas.height = @dropletElement.offsetHeight
+    @cursorCanvas.height = @dropletElement.offsetHeight - @gutterElement.offsetWidth
     @cursorCanvas.style.height = "#{@cursorCanvas.height}px"
 
     @cursorCanvas.style.left = "#{@mainCanvas.offsetLeft}px"

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -908,10 +908,10 @@ define ['droplet-helper',
     @dragCanvas.width = 0
     @dragCanvas.height = 0
 
-    @highlightCanvas.width = @dropletElement.offsetWidth - @gutterElement.offsetWidth
+    @highlightCanvas.width = @dropletElement.offsetWidth - @gutter.offsetWidth
     @highlightCanvas.style.width = "#{@highlightCanvas.width}px"
 
-    @highlightCanvas.height = @dropletElement.offsetHeight - @gutterElement.offsetWidth
+    @highlightCanvas.height = @dropletElement.offsetHeight - @gutter.offsetWidth
     @highlightCanvas.style.height = "#{@highlightCanvas.height}px"
 
     @highlightCanvas.style.left = "#{@mainCanvas.offsetLeft}px"
@@ -2161,10 +2161,10 @@ define ['droplet-helper',
   # Deal with resize for the lasso
   # select canvas
   Editor::resizeLassoCanvas = ->
-    @lassoSelectCanvas.width = @dropletElement.offsetWidth - @gutterElement.offsetWidth
+    @lassoSelectCanvas.width = @dropletElement.offsetWidth - @gutter.offsetWidth
     @lassoSelectCanvas.style.width = "#{@lassoSelectCanvas.width}px"
 
-    @lassoSelectCanvas.height = @dropletElement.offsetHeight - @gutterElement.offsetWidth
+    @lassoSelectCanvas.height = @dropletElement.offsetHeight - @gutter.offsetWidth
     @lassoSelectCanvas.style.height = "#{@lassoSelectCanvas.height}px"
 
     @lassoSelectCanvas.style.left = "#{@mainCanvas.offsetLeft}px"
@@ -3810,10 +3810,10 @@ define ['droplet-helper',
     @dropletElement.appendChild @cursorCanvas
 
   Editor::resizeCursorCanvas = ->
-    @cursorCanvas.width = @dropletElement.offsetWidth - @gutterElement.offsetWidth
+    @cursorCanvas.width = @dropletElement.offsetWidth - @gutter.offsetWidth
     @cursorCanvas.style.width = "#{@cursorCanvas.width}px"
 
-    @cursorCanvas.height = @dropletElement.offsetHeight - @gutterElement.offsetWidth
+    @cursorCanvas.height = @dropletElement.offsetHeight - @gutter.offsetWidth
     @cursorCanvas.style.height = "#{@cursorCanvas.height}px"
 
     @cursorCanvas.style.left = "#{@mainCanvas.offsetLeft}px"


### PR DESCRIPTION
Some of the layers (cursor, highlight, lasso) were too wide, because of the gutter; reduce their width to fit inside the wrapper div.