### PR TITLE
Fix palette highlight position and empty header.

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -1461,6 +1461,9 @@ define ['droplet-helper',
         paletteHeaderRow = document.createElement 'div'
         paletteHeaderRow.className = 'droplet-palette-header-row'
         @paletteHeader.appendChild paletteHeaderRow
+        # hide the header if there is only one group, and it has no name.
+        if @paletteGroups.length is 1 and paletteGroup.name is ''
+          paletteHeaderRow.style.height = 0
 
       # Create the element itself
       paletteGroupHeader = document.createElement 'div'
@@ -1520,6 +1523,7 @@ define ['droplet-helper',
         do updatePalette
 
     @resizePalette()
+    @resizePaletteHighlight()
 
   # The next thing we need to do with the palette
   # is let people pick things up from it.

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -1462,7 +1462,7 @@ define ['droplet-helper',
         paletteHeaderRow.className = 'droplet-palette-header-row'
         @paletteHeader.appendChild paletteHeaderRow
         # hide the header if there is only one group, and it has no name.
-        if @paletteGroups.length is 1 and paletteGroup.name is ''
+        if @paletteGroups.length is 1 and !paletteGroup.name
           paletteHeaderRow.style.height = 0
 
       # Create the element itself


### PR DESCRIPTION
When the palette is resized (after changing the palette header),
the palette highlight canvas should also be resized, so the
highlight outlines are positioned correctly.

Also, if the palette header has only a single group and it
has no name, then the palette header is formatted so that
the palette header is not visible.