### PR TITLE
option to always show palette

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -1696,7 +1696,10 @@ define ['droplet-helper',
           @redrawTextInput()
 
   Editor::resizeAceElement = ->
-    @aceElement.style.width = "#{@wrapperElement.offsetWidth}px"
+    width = @wrapperElement.offsetWidth
+    if @alwaysShowPalette
+      width -= @paletteElement.offsetWidth
+    @aceElement.style.width = "#{width}px"
     @aceElement.style.height = "#{@wrapperElement.offsetHeight}px"
 
   last_ = (array) -> array[array.length - 1]

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -140,6 +140,7 @@ define ['droplet-helper',
   exports.Editor = class Editor
     constructor: (@wrapperElement, @options) ->
       @paletteGroups = @options.palette
+      @alwaysShowPalette = @options.alwaysShowPalette ? false
 
       @options.mode = @options.mode.replace /$\/ace\/mode\//, ''
 
@@ -3118,28 +3119,33 @@ define ['droplet-helper',
         @highlightCanvas.style.opacity =
         @cursorCanvas.style.opacity = 0
 
-      setTimeout (=>
-        @dropletElement.style.transition =
-          @paletteWrapper.style.transition = "left #{translateTime}ms"
+      if not @alwaysShowPalette
+        setTimeout (=>
+          @dropletElement.style.transition =
+            @paletteWrapper.style.transition = "left #{translateTime}ms"
 
-        @dropletElement.style.left = '0px'
-        @paletteWrapper.style.left = "#{-@paletteWrapper.offsetWidth}px"
-      ), fadeTime
+          @dropletElement.style.left = '0px'
+          @paletteWrapper.style.left = "#{-@paletteWrapper.offsetWidth}px"
+        ), fadeTime
 
       setTimeout (=>
         # Translate the ICE editor div out of frame.
         @dropletElement.style.transition =
           @paletteWrapper.style.transition = ''
 
-        @dropletElement.style.top = '-9999px'
-        @dropletElement.style.left = '-9999px'
-
-        @paletteWrapper.style.top = '-9999px'
-        @paletteWrapper.style.left = '-9999px'
+        if not @alwaysShowPalette
+          @paletteWrapper.style.top = '-9999px'
+          @paletteWrapper.style.left = '-9999px'
 
         # Translate the ACE editor div into frame.
-        @aceElement.style.top = "0px"
-        @aceElement.style.left = "0px"
+        @aceElement.style.top = '0px'
+        if @alwaysShowPalette
+          @aceElement.style.left = @paletteWrapper.style.width
+        else
+          @aceElement.style.left = '0px'
+
+        @dropletElement.style.top = '-9999px'
+        @dropletElement.style.left = '-9999px'
 
         # Finalize a bunch of animations
         # that should be complete by now,
@@ -3194,7 +3200,9 @@ define ['droplet-helper',
         @aceElement.style.left = "-9999px"
 
         @paletteWrapper.style.top = '0px'
-        @paletteWrapper.style.left = "#{-@paletteWrapper.offsetWidth}px"
+        if not @alwaysShowPalette
+          # Don't need to move palette if already showing
+          @paletteWrapper.style.left = "#{-@paletteWrapper.offsetWidth}px"
 
         @dropletElement.style.top = "0px"
         @dropletElement.style.left = "0px"
@@ -3287,8 +3295,9 @@ define ['droplet-helper',
 
         ), translateTime
 
-        @dropletElement.style.transition =
-          @paletteWrapper.style.transition = "left #{fadeTime}ms"
+        if not @alwaysShowPalette
+          @dropletElement.style.transition =
+            @paletteWrapper.style.transition = "left #{fadeTime}ms"
 
         @dropletElement.style.left = "#{@paletteWrapper.offsetWidth}px"
         @paletteWrapper.style.left = '0px'

--- a/test/coffee/tests.coffee
+++ b/test/coffee/tests.coffee
@@ -1137,3 +1137,53 @@ require ['droplet-helper', 'droplet-model', 'droplet-parser', 'droplet-coffee', 
     # no-throw
     editor.setTextInputFocus editor.tree.getBlockOnLine(0).end.prev.container
     editor.showDropdown()
+
+  asyncTest 'Controller: alwaysShowPalette false', ->
+    expect 4
+
+    states = []
+    document.getElementById('test-main').innerHTML = ''
+    editor = new droplet.Editor document.getElementById('test-main'), {
+      mode: 'coffeescript'
+      palette: [],
+      alwaysShowPalette: false
+    }
+
+    paletteWrapper = document.querySelector('.droplet-palette-wrapper')
+    aceEditor = document.querySelector('.ace_editor')
+
+    editor.on 'statechange', (usingBlocks) ->
+      states.push usingBlocks
+
+    editor.performMeltAnimation 10, 10, ->
+      strictEqual paletteWrapper.style.left, '-9999px'
+      strictEqual aceEditor.style.left, '0px'
+      editor.performFreezeAnimation 10, 10, ->
+        strictEqual paletteWrapper.style.left, '0px'
+        strictEqual aceEditor.style.left, '-9999px'
+        start()
+
+  asyncTest 'Controller: alwaysShowPalette true', ->
+    expect 4
+
+    states = []
+    document.getElementById('test-main').innerHTML = ''
+    editor = new droplet.Editor document.getElementById('test-main'), {
+      mode: 'coffeescript'
+      palette: [],
+      alwaysShowPalette: true
+    }
+
+    paletteWrapper = document.querySelector('.droplet-palette-wrapper')
+    aceEditor = document.querySelector('.ace_editor')
+
+    editor.on 'statechange', (usingBlocks) ->
+      states.push usingBlocks
+
+    editor.performMeltAnimation 10, 10, ->
+      strictEqual paletteWrapper.style.left, '0px'
+      strictEqual aceEditor.style.left, '270px'
+      editor.performFreezeAnimation 10, 10, ->
+        strictEqual paletteWrapper.style.left, '0px'
+        strictEqual aceEditor.style.left, '-9999px'
+        start()


### PR DESCRIPTION
![keeppalette](https://cloud.githubusercontent.com/assets/1767466/6735619/8bc08670-ce1c-11e4-98c5-17b20fb6448a.gif)

This adds an option to keep the palette around in code mode. Not sure whether this better belongs as a child of modeOptions?

I also added a couple of tests, and verified that when alwaysShowPalette is false or undefined, the behavior remains unchanged.

Haven't really written coffee script before, so let me know if there are coffee script conventions I've violated.