### PR TITLE
Support empty indents in Javascript

### DIFF
--- a/src/coffee.coffee
+++ b/src/coffee.coffee
@@ -460,7 +460,7 @@ define ['droplet-helper', 'droplet-model', 'droplet-parser', 'coffee-script'], (
 
           # Fake-remove backticks hack
           else if node.base.nodeType() is 'Literal' and
-              node.base.value is ''
+              (node.base.value is '' or node.base.value is @empty)
             fakeBlock =
                 @csBlock node.base, depth, 0, wrappingParen, ANY_DROP
             fakeBlock.flagToRemove = true
@@ -1008,6 +1008,7 @@ define ['droplet-helper', 'droplet-model', 'droplet-parser', 'coffee-script'], (
     lines.splice n + 1, 0, leading[0] + '  ``'
 
   CoffeeScriptParser.empty = "``"
+  CoffeeScriptParser.emptyIndent = "``"
 
   CoffeeScriptParser.drop = (block, context, pred) ->
     if context.type is 'socket'

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -1235,7 +1235,7 @@ define ['droplet-helper',
 
   Editor::reparseRawReplace = (oldBlock) ->
     try
-      newParse = @mode.parse(oldBlock.stringify(@mode.empty), wrapAtRoot: true)
+      newParse = @mode.parse(oldBlock.stringify(@mode), wrapAtRoot: true)
       newBlock = newParse.start.next.container
       if newParse.start.next.container.end is newParse.end.prev and
           newBlock?.type is 'block'
@@ -1587,7 +1587,7 @@ define ['droplet-helper',
       hoverDiv = document.createElement 'div'
       hoverDiv.className = 'droplet-hover-div'
 
-      hoverDiv.title = data.title ? block.stringify(@mode.empty)
+      hoverDiv.title = data.title ? block.stringify(@mode)
 
       bounds = @view.getViewNodeFor(block).totalBounds
 
@@ -1702,7 +1702,7 @@ define ['droplet-helper',
 
   # Redraw function for text input
   Editor::redrawTextInput = ->
-    sameLength = @textFocus.stringify(@mode.empty).split('\n').length is @hiddenInput.value.split('\n').length
+    sameLength = @textFocus.stringify(@mode).split('\n').length is @hiddenInput.value.split('\n').length
 
     # Set the value in the model to fit
     # the hidden input value.
@@ -1712,8 +1712,8 @@ define ['droplet-helper',
 
     # Determine the coordinate positions
     # of the typing cursor
-    startRow = @textFocus.stringify(@mode.empty)[...@hiddenInput.selectionStart].split('\n').length - 1
-    endRow = @textFocus.stringify(@mode.empty)[...@hiddenInput.selectionEnd].split('\n').length - 1
+    startRow = @textFocus.stringify(@mode)[...@hiddenInput.selectionStart].split('\n').length - 1
+    endRow = @textFocus.stringify(@mode)[...@hiddenInput.selectionEnd].split('\n').length - 1
 
     # Redraw the main canvas, on top of
     # which we will draw the cursor and
@@ -1768,17 +1768,17 @@ define ['droplet-helper',
 
     # Determine the coordinate positions
     # of the typing cursor
-    startRow = @textFocus.stringify(@mode.empty)[...@hiddenInput.selectionStart].split('\n').length - 1
-    endRow = @textFocus.stringify(@mode.empty)[...@hiddenInput.selectionEnd].split('\n').length - 1
+    startRow = @textFocus.stringify(@mode)[...@hiddenInput.selectionStart].split('\n').length - 1
+    endRow = @textFocus.stringify(@mode)[...@hiddenInput.selectionEnd].split('\n').length - 1
 
-    lines = @textFocus.stringify(@mode.empty).split '\n'
+    lines = @textFocus.stringify(@mode).split '\n'
 
     startPosition = textFocusView.bounds[startRow].x + @view.opts.textPadding +
-      @mainCtx.measureText(last_(@textFocus.stringify(@mode.empty)[...@hiddenInput.selectionStart].split('\n'))).width +
+      @mainCtx.measureText(last_(@textFocus.stringify(@mode)[...@hiddenInput.selectionStart].split('\n'))).width +
       (if @textFocus.hasDropdown() then helper.DROPDOWN_ARROW_WIDTH else 0)
 
     endPosition = textFocusView.bounds[endRow].x + @view.opts.textPadding +
-      @mainCtx.measureText(last_(@textFocus.stringify(@mode.empty)[...@hiddenInput.selectionEnd].split('\n'))).width +
+      @mainCtx.measureText(last_(@textFocus.stringify(@mode)[...@hiddenInput.selectionEnd].split('\n'))).width +
       (if @textFocus.hasDropdown() then helper.DROPDOWN_ARROW_WIDTH else 0)
 
     # Now draw the highlight/typing cursor
@@ -1839,7 +1839,7 @@ define ['droplet-helper',
       @addMicroUndoOperation new TextChangeOperation @textFocus, @oldFocusValue, @
       @oldFocusValue = null
 
-      originalText = @textFocus.stringify(@mode.empty)
+      originalText = @textFocus.stringify(@mode)
       shouldPop = false
       shouldRecoverCursor = false
       cursorPosition = cursorParent = null
@@ -1853,7 +1853,7 @@ define ['droplet-helper',
       # value.
       unless @textFocus.handwritten
         newParse = null
-        string = @textFocus.stringify(@mode.empty).trim()
+        string = @textFocus.stringify(@mode).trim()
         try
           newParse = @mode.parse(unparsedValue = string, wrapAtRoot: false)
         catch
@@ -1901,14 +1901,14 @@ define ['droplet-helper',
       return
 
     # Record old focus value
-    @oldFocusValue = focus.stringify(@mode.empty)
+    @oldFocusValue = focus.stringify(@mode)
 
     # Now create a text token
     # with the appropriate text to put in it.
     @textFocus = focus
 
     # Immediately rerender.
-    @populateSocket focus, focus.stringify(@mode.empty)
+    @populateSocket focus, focus.stringify(@mode)
 
     @textFocus.notifyChange()
 
@@ -1916,7 +1916,7 @@ define ['droplet-helper',
     @moveCursorTo focus.end
 
     # Set the hidden input up to mirror the text.
-    @hiddenInput.value = @textFocus.stringify(@mode.empty)
+    @hiddenInput.value = @textFocus.stringify(@mode)
 
     if selectionStart? and not selectionEnd?
       selectionEnd = selectionStart
@@ -1972,7 +1972,7 @@ define ['droplet-helper',
 
     column = Math.max 0, Math.round((point.x - textFocusView.bounds[row].x - @view.opts.textPadding - (if @textFocus.hasDropdown() then helper.DROPDOWN_ARROW_WIDTH else 0)) / @mainCtx.measureText(' ').width)
 
-    lines = @textFocus.stringify(@mode.empty).split('\n')[..row]
+    lines = @textFocus.stringify(@mode).split('\n')[..row]
     lines[lines.length - 1] = lines[lines.length - 1][...column]
 
     return lines.join('\n').length
@@ -1984,8 +1984,8 @@ define ['droplet-helper',
   Editor::selectDoubleClick = (point) ->
     position = @getTextPosition point
 
-    before = @textFocus.stringify(@mode.empty)[...position].match(/\w*$/)[0]?.length ? 0
-    after = @textFocus.stringify(@mode.empty)[position..].match(/^\w*/)[0]?.length ? 0
+    before = @textFocus.stringify(@mode)[...position].match(/\w*$/)[0]?.length ? 0
+    after = @textFocus.stringify(@mode)[position..].match(/^\w*/)[0]?.length ? 0
 
     @textInputAnchor = position - before
     @textInputHead = position + after
@@ -3597,7 +3597,7 @@ define ['droplet-helper',
 
       newParse = @mode.parse value, wrapAtRoot: true
 
-      if value isnt @tree.stringify(@mode.empty)
+      if value isnt @tree.stringify(@mode)
         @addMicroUndoOperation 'CAPTURE_POINT'
       @addMicroUndoOperation new SetValueOperation @tree, newParse
 
@@ -3637,7 +3637,7 @@ define ['droplet-helper',
 
   Editor::getValue = ->
     if @currentlyUsingBlocks
-      return @addEmptyLine @tree.stringify(@mode.empty)
+      return @addEmptyLine @tree.stringify(@mode)
     else
       @getAceValue()
 
@@ -4134,7 +4134,7 @@ define ['droplet-helper',
         window.scrollTo(x, y)
 
         if @lassoSegment?
-          @copyPasteInput.value = @lassoSegment.stringify(@mode.empty)
+          @copyPasteInput.value = @lassoSegment.stringify(@mode)
         @copyPasteInput.setSelectionRange 0, @copyPasteInput.value.length
 
   hook 'keyup', 0, (point, event, state) ->

--- a/src/javascript.coffee
+++ b/src/javascript.coffee
@@ -568,5 +568,6 @@ define ['droplet-helper', 'droplet-model', 'droplet-parser', 'acorn'], (helper, 
     return helper.DISCOURAGE
 
   JavaScriptParser.empty = "__"
+  JavaScriptParser.emptyIndent = ""
 
   return parser.wrapParser JavaScriptParser

--- a/src/model.coffee
+++ b/src/model.coffee
@@ -236,13 +236,16 @@ define ['droplet-helper'], (helper) ->
     # Get a string representation of us,
     # using the `stringify()` method on all of
     # the tokens that we contain.
-    stringify: (emptyToken = '') ->
+    stringify: (config) ->
+      emptySocket = config.empty or ''
+      emptyIndent = config.emptyIndent or config.empty
       str = ''
 
       head = @start.next
       state =
         indent: ''
-        emptyToken: emptyToken
+        emptySocket: emptySocket
+        emptyIndent: emptyIndent
 
       until head is @end
         str += head.stringify state
@@ -745,7 +748,7 @@ define ['droplet-helper'], (helper) ->
     constructor: (@container) -> super; @type = 'socketStart'
     stringify: (state) ->
       if @next is @container.end or
-        @next.type is 'text' and @next.value is '' then state.emptyToken else ''
+        @next.type is 'text' and @next.value is '' then state.emptySocket else ''
 
   exports.SocketEndToken = class SocketEndToken extends EndToken
     constructor: (@container) -> super; @type = 'socketEnd'
@@ -792,7 +795,7 @@ define ['droplet-helper'], (helper) ->
     stringify: (state) ->
       unless @container.prefix.length is 0
         state.indent = state.indent[...-@container.prefix.length]
-      if @previousVisibleToken().previousVisibleToken() is @container.start then state.emptyToken else ''
+      if @previousVisibleToken().previousVisibleToken() is @container.start then state.emptyIndent else ''
     serialize: -> "</indent>"
 
   exports.Indent = class Indent extends Container

--- a/src/model.coffee
+++ b/src/model.coffee
@@ -238,7 +238,7 @@ define ['droplet-helper'], (helper) ->
     # the tokens that we contain.
     stringify: (config) ->
       emptySocket = config.empty or ''
-      emptyIndent = config.emptyIndent or config.empty
+      emptyIndent = config.emptyIndent or ''
       str = ''
 
       head = @start.next

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -459,11 +459,13 @@ define ['droplet-helper', 'droplet-model'], (helper, model) ->
       return helper.ENCOURAGE
 
   Parser.empty = ''
+  Parser.emptyIndent = ''
 
   exports.wrapParser = (CustomParser) ->
     class CustomParserFactory extends ParserFactory
       constructor: (@opts = {}) ->
         @empty = CustomParser.empty
+        @emptyIndent = CustomParser.emptyIndent
 
       createParser: (text) -> new CustomParser text, @opts
 

--- a/test/coffee/parserTests.coffee
+++ b/test/coffee/parserTests.coffee
@@ -20,7 +20,7 @@ describe 'Parser unity', (done) ->
   testString = (str) ->
     it 'should round-trip ' + str.split('\n')[0] +
         (if str.split('\n').length > 1 then '...' else ''), ->
-      assert.equal str, coffee.parse(str, wrapAtRoot: true).stringify()
+      assert.equal str, coffee.parse(str, wrapAtRoot: true).stringify(coffee)
   testString '/// #{x} ///'
   testString 'fd 10'
   testString 'fd 10 + 10'
@@ -49,7 +49,7 @@ describe 'Parser unity', (done) ->
     it "should round-trip on #{name}", ->
       file = fs.readFileSync(name).toString()
 
-      unparsed = coffee.parse(file, wrapAtRoot: true).stringify()
+      unparsed = coffee.parse(file, wrapAtRoot: true).stringify(coffee)
 
       filelines = file.split '\n'
       for line, i in unparsed.split '\n'

--- a/test/coffee/tests.coffee
+++ b/test/coffee/tests.coffee
@@ -113,10 +113,10 @@ require ['droplet-helper', 'droplet-model', 'droplet-parser', 'droplet-coffee', 
       console.log j
     '''
 
-    strictEqual document.getBlockOnLine(1).stringify(coffee.empty), 'console.log i', 'line 1'
-    strictEqual document.getBlockOnLine(3).stringify(coffee.empty), 'console.log k', 'line 3'
-    strictEqual document.getBlockOnLine(5).stringify(coffee.empty), 'console.log q', 'line 5'
-    strictEqual document.getBlockOnLine(7).stringify(coffee.empty), 'console.log j', 'line 7'
+    strictEqual document.getBlockOnLine(1).stringify(coffee), 'console.log i', 'line 1'
+    strictEqual document.getBlockOnLine(3).stringify(coffee), 'console.log k', 'line 3'
+    strictEqual document.getBlockOnLine(5).stringify(coffee), 'console.log q', 'line 5'
+    strictEqual document.getBlockOnLine(7).stringify(coffee), 'console.log j', 'line 7'
     start()
 
   asyncTest 'Location serialization unity', ->
@@ -142,7 +142,7 @@ require ['droplet-helper', 'droplet-model', 'droplet-parser', 'droplet-coffee', 
 
     document.getBlockOnLine(2).moveTo document.start, coffee
 
-    strictEqual document.stringify(coffee.empty), '''
+    strictEqual document.stringify(coffee), '''
     console.log world
     for i in [1..10]
       console.log hello
@@ -150,7 +150,7 @@ require ['droplet-helper', 'droplet-model', 'droplet-parser', 'droplet-coffee', 
 
     document.getBlockOnLine(2).moveTo document.start, coffee
 
-    strictEqual document.stringify(coffee.empty), '''
+    strictEqual document.stringify(coffee), '''
     console.log hello
     console.log world
     for i in [1..10]
@@ -159,7 +159,7 @@ require ['droplet-helper', 'droplet-model', 'droplet-parser', 'droplet-coffee', 
 
     document.getBlockOnLine(0).moveTo document.getBlockOnLine(2).end.prev.container.start, coffee
 
-    strictEqual document.stringify(coffee.empty), '''
+    strictEqual document.stringify(coffee), '''
     console.log world
     for i in [1..10]
       console.log hello
@@ -167,7 +167,7 @@ require ['droplet-helper', 'droplet-model', 'droplet-parser', 'droplet-coffee', 
 
     document.getBlockOnLine(1).moveTo document.getBlockOnLine(0).end.prev.container.start, coffee
 
-    strictEqual document.stringify(coffee.empty), '''
+    strictEqual document.stringify(coffee), '''
     console.log (for i in [1..10]
       console.log hello)
     ''', 'Move for into socket (req. paren wrap)'
@@ -183,7 +183,7 @@ require ['droplet-helper', 'droplet-model', 'droplet-parser', 'droplet-coffee', 
 
     document.getBlockOnLine(2).moveTo document.getBlockOnLine(1).end.prev.container.start, coffee
 
-    strictEqual document.stringify(coffee.empty), '''
+    strictEqual document.stringify(coffee), '''
     for i in [1..10]
       for i in [1..10]
         alert 10
@@ -198,13 +198,13 @@ require ['droplet-helper', 'droplet-model', 'droplet-parser', 'droplet-coffee', 
 
     (block = document.getBlockOnLine(0)).moveTo document.getBlockOnLine(1).end.prev.prev.prev.container.start, coffee
 
-    strictEqual document.stringify(coffee.empty), '''
+    strictEqual document.stringify(coffee), '''
     console.log 1 + (Math.sqrt 2)
     ''', 'Wrap'
 
     block.moveTo document.start, coffee
 
-    strictEqual document.stringify(coffee.empty), '''
+    strictEqual document.stringify(coffee), '''
     Math.sqrt 2
     console.log 1 + ``''', 'Unwrap'
     start()
@@ -257,7 +257,7 @@ require ['droplet-helper', 'droplet-model', 'droplet-parser', 'droplet-coffee', 
     documentView.layout()
 
     indentView = view_.getViewNodeFor document.getBlockOnLine(1).end.prev.container
-    strictEqual indentView.lineChildren[1][0].child.stringify(coffee.empty), 'alert 10', 'Relative line numbers'
+    strictEqual indentView.lineChildren[1][0].child.stringify(coffee), 'alert 10', 'Relative line numbers'
 
     document = coffee.parse '''
     console.log (for [1..10]
@@ -370,7 +370,7 @@ require ['droplet-helper', 'droplet-model', 'droplet-parser', 'droplet-coffee', 
 
     socketView = view_.getViewNodeFor document.getTokenAtLocation(8).container
 
-    strictEqual socketView.model.stringify(coffee.empty), '[[[]]]', 'Correct block selected'
+    strictEqual socketView.model.stringify(coffee), '[[[]]]', 'Correct block selected'
 
     strictEqual socketView.dimensions[0].height,
       view_.opts.textHeight + 6 * view_.opts.padding,
@@ -441,7 +441,7 @@ require ['droplet-helper', 'droplet-model', 'droplet-parser', 'droplet-coffee', 
 
     socketView = view_.getViewNodeFor document.getTokenAtLocation(4).container
 
-    strictEqual socketView.model.stringify(coffee.empty), '\'hi\'', 'Correct block selected'
+    strictEqual socketView.model.stringify(coffee), '\'hi\'', 'Correct block selected'
     strictEqual socketView.dimensions[0].height, view_.opts.textHeight + 2 * view_.opts.textPadding, 'Original height O.K.'
     strictEqual socketView.topLineSticksToBottom, false, 'Original topstick O.K.'
 
@@ -785,7 +785,7 @@ require ['droplet-helper', 'droplet-model', 'droplet-parser', 'droplet-coffee', 
 
     key = editor.mark 2, 4, {color: '#F00'}
 
-    strictEqual editor.markedBlocks[key].model.stringify(), '10 - 10'
+    strictEqual editor.markedBlocks[key].model.stringify({}), '10 - 10'
     strictEqual editor.markedBlocks[key].style.color, '#F00'
 
     editor.unmark key

--- a/test/jstest.html
+++ b/test/jstest.html
@@ -229,6 +229,17 @@ function(helper, JavaScript, droplet) {
         'JS Custom colors work');
     start();
   });
+
+  asyncTest('JS empty indents', function() {
+    var customJS, customSerialization, code, stringifiedJS;
+    customJS = new JavaScript();
+    code = 'if (__) {\n\n}';
+    customSerialization = customJS.parse('if (__) {\n\n}');
+    stringifiedJS = customSerialization.stringify(customJS);
+    strictEqual(code, stringifiedJS);
+    start();
+  });
+
 });
 </script>
 </html>


### PR DESCRIPTION
When a Javascript block is empty but surrounded by curly braces, it should be serialized with nothing between the curly braces.  This is different from coffeescript, which needs something inside the indented code.

This change adds support for allowing a language adapter to support "empty indents".