### PR TITLE
Add expansion blocks to palette

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -7,6 +7,15 @@ notify = (message) ->
     fallback: 0
   ), ->
 
+serveNoDottedFiles = (connect, options, middlewares) ->
+  # Avoid leaking .git/.svn or other dotted files from test servers.
+  middlewares.unshift (req, res, next) ->
+    if req.url.indexOf('/.') < 0 then return next()
+    res.statusCode = 404
+    res.setHeader('Content-Type', 'text/html');
+    res.end "Cannot GET #{req.url}"
+  return middlewares
+
 module.exports = (grunt) ->
   grunt.initConfig
     pkg: grunt.file.readJSON 'package.json'
@@ -130,10 +139,12 @@ module.exports = (grunt) ->
       testserver:
         options:
           hostname: '0.0.0.0'
+          middleware: serveNoDottedFiles
       qunitserver:
         options:
           hostname: '0.0.0.0'
           port: 8942
+          middleware: serveNoDottedFiles
 
     watch:
       options:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,11 @@ require ['droplet'], (droplet) ->
           {
             block: "for [1..3]\n  ``"
             title: "Repeat some code" # title-text
-          }
+          },
+          {
+            block: "playSomething()"
+            expansion: "playSomething 'arguments', 100, 'too long to show'"
+          },
         ]
       }
     ]
@@ -209,7 +213,7 @@ MyParser.drop = (block, context, preceding) ->
   # block: the block that user is dragging
   # context: the place the user is dropping that block into
   # preceding: if in sequence, the block immediately before
-  
+
   # block, context, and preceding will have
   # properties `classes` (from when you created the block),
   # `precedence`, and `type` ('block', 'socket', 'indent', or 'segment')

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -333,13 +333,13 @@ define ['droplet-helper',
     resizeBlockMode: ->
       @resizeTextMode()
 
-      @dropletElement.style.height = "#{@wrapperElement.offsetHeight}px"
+      @dropletElement.style.height = "#{@wrapperElement.clientHeight}px"
       if @paletteEnabled
         @dropletElement.style.left = "#{@paletteElement.offsetWidth}px"
-        @dropletElement.style.width = "#{@wrapperElement.offsetWidth - @paletteWrapper.offsetWidth}px"
+        @dropletElement.style.width = "#{@wrapperElement.clientWidth - @paletteWrapper.offsetWidth}px"
       else
         @dropletElement.style.left = "0px"
-        @dropletElement.style.width = "#{@wrapperElement.offsetWidth}px"
+        @dropletElement.style.width = "#{@wrapperElement.clientWidth}px"
 
       @resizeGutter()
 
@@ -1762,12 +1762,12 @@ define ['droplet-helper',
           @redrawTextInput()
 
   Editor::resizeAceElement = ->
-    width = @wrapperElement.offsetWidth
+    width = @wrapperElement.clientWidth
     if @showPaletteInTextMode and @paletteEnabled
       width -= @paletteElement.offsetWidth
 
     @aceElement.style.width = "#{width}px"
-    @aceElement.style.height = "#{@wrapperElement.offsetHeight}px"
+    @aceElement.style.height = "#{@wrapperElement.clientHeight}px"
 
   last_ = (array) -> array[array.length - 1]
 
@@ -3100,7 +3100,7 @@ define ['droplet-helper',
       else
         @mainScroller.style.overflowX = 'hidden'
       @mainScroller.style.overflowY = 'hidden'
-      @dropletElement.style.width = @wrapperElement.offsetWidth + 'px'
+      @dropletElement.style.width = @wrapperElement.clientWidth + 'px'
 
       @currentlyUsingBlocks = false; @currentlyAnimating = @currentlyAnimating_suppressRedraw = true
 
@@ -3263,7 +3263,7 @@ define ['droplet-helper',
       setTimeout (=>
         # Hide scrollbars and increase width
         @mainScroller.style.overflow = 'hidden'
-        @dropletElement.style.width = @wrapperElement.offsetWidth + 'px'
+        @dropletElement.style.width = @wrapperElement.clientWidth + 'px'
 
         @redrawMain noText: true
 

--- a/test/uitest.html
+++ b/test/uitest.html
@@ -36,20 +36,24 @@ require([
       target = $(target).get(0);
     }
     options = options || {};
-    var pageX = pageY = clientX = clientY = 0;
+    var pageX = pageY = clientX = clientY = dx = dy = 0;
     var location = options.location || target;
     if (location) {
       if ('string' == typeof(location)) {
         location = $(location).get(0);
       }
       var gbcr = location.getBoundingClientRect();
-      clientX = Math.floor((gbcr.left + gbcr.right) / 2);
-      clientY = Math.floor((gbcr.top + gbcr.bottom) / 2);
+      clientX = gbcr.left,
+      clientY = gbcr.top,
       pageX = clientX + window.pageXOffset;
       pageY = clientY + window.pageYOffset;
+      dx = Math.floor((gbcr.right - gbcr.left) / 2);
+      dy = Math.floor((gbcr.bottom - gbcr.top) / 2);
     }
-    pageX = (options.pageX == null ? pageX : options.pageX) + (options.dx || 0);
-    pageY = (options.pageY == null ? pageY : options.pageY) + (options.dy || 0);
+    if ('dx' in options) dx = options.dx;
+    if ('dy' in options) dy = options.dy;
+    pageX = (options.pageX == null ? pageX : options.pageX) + dx;
+    pageY = (options.pageY == null ? pageY : options.pageY) + dy;
     clientX = pageX - window.pageXOffset;
     clientY = pageY - window.pageYOffset;
     var opts = {
@@ -103,6 +107,7 @@ require([
     var editor, states;
     states = [];
     document.getElementById('test-main').innerHTML = '';
+    varcount = 0;
     window.editor = editor = new droplet.Editor(document.getElementById('test-main'), {
       mode: 'coffeescript',
       palette: [{
@@ -112,7 +117,12 @@ require([
           block: 'pen()',
           expansion: 'pen red',
           title: 'ptest'
-        }],
+        }, {
+          block: 'a = b',
+          expansion: function() { return 'a' + (++varcount) + ' = b'; },
+          title: 'ftest'
+        },
+        ],
       }]
     });
     simulate('mousedown', '[title=ptest]');
@@ -123,6 +133,22 @@ require([
     simulate('mouseup', '.droplet-drag-cover',
       { location: '.droplet-main-scroller' });
     equal(editor.getValue().trim(), 'pen red');
+    simulate('mousedown', '[title=ftest]');
+    simulate('mousemove', '.droplet-drag-cover',
+      { location: '[title=ftest]', dx: 5 });
+    simulate('mousemove', '.droplet-drag-cover',
+      { location: '.droplet-main-scroller', dx: 40, dy: 50 });
+    simulate('mouseup', '.droplet-drag-cover',
+      { location: '.droplet-main-scroller', dx: 40, dy: 50 });
+    equal(editor.getValue().trim(), 'pen red\na1 = b');
+    simulate('mousedown', '[title=ftest]');
+    simulate('mousemove', '.droplet-drag-cover',
+      { location: '[title=ftest]', dx: 5 });
+    simulate('mousemove', '.droplet-drag-cover',
+      { location: '.droplet-main-scroller', dx: 40, dy: 80 });
+    simulate('mouseup', '.droplet-drag-cover',
+      { location: '.droplet-main-scroller', dx: 40, dy: 80 });
+    equal(editor.getValue().trim(), 'pen red\na1 = b\na2 = b');
     start();
   });
 });

--- a/test/uitest.html
+++ b/test/uitest.html
@@ -1,0 +1,130 @@
+<html>
+  <head>
+    <link rel="stylesheet" href="../vendor/qunit.css"/>
+    <link rel="stylesheet" href="../dist/droplet.min.css"/>
+    <style>
+      #test-main {
+        position: absolute;
+        top: 100px;
+        right: 0;
+        border: 5px solid red;
+        height: 300px;
+        width: 500px;
+      }
+    </style>
+  </head>
+  <div id="qunit"></div>
+  <div id="qunit-fixture"></div>
+  <div id="test-main">
+  </div>
+  <script src="../vendor/require.js"></script>
+  <script src="../vendor/ace/ace.js"></script>
+  <script src="../dist/droplet-full.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+  <script src="../vendor/qunit.js"></script>
+<script>
+require([
+  'droplet-helper',
+  'droplet-model',
+  'droplet-parser',
+  'droplet-view',
+  'droplet'
+], function(helper, model, parser, view, droplet) {
+
+  function simulate(type, target, options) {
+    if ('string' == typeof(target)) {
+      target = $(target).get(0);
+    }
+    options = options || {};
+    var pageX = pageY = clientX = clientY = 0;
+    var location = options.location || target;
+    if (location) {
+      if ('string' == typeof(location)) {
+        location = $(location).get(0);
+      }
+      var gbcr = location.getBoundingClientRect();
+      clientX = Math.floor((gbcr.left + gbcr.right) / 2);
+      clientY = Math.floor((gbcr.top + gbcr.bottom) / 2);
+      pageX = clientX + window.pageXOffset;
+      pageY = clientY + window.pageYOffset;
+    }
+    pageX = (options.pageX == null ? pageX : options.pageX) + (options.dx || 0);
+    pageY = (options.pageY == null ? pageY : options.pageY) + (options.dy || 0);
+    clientX = pageX - window.pageXOffset;
+    clientY = pageY - window.pageYOffset;
+    var opts = {
+        bubbles: options.bubbles || true,
+        cancelable: options.cancelable || true,
+        view: options.view || target.ownerDocument.defaultView,
+        detail: options.detail || 1,
+        pageX: pageX,
+        pageY: pageY,
+        clientX: clientX,
+        clientY: clientY,
+        screenX: clientX + window.screenLeft,
+        screenY: clientY + window.screenTop,
+        ctrlKey: options.ctrlKey || false,
+        altKey: options.altKey || false,
+        shiftKey: options.shiftKey || false,
+        metaKey: options.metaKey || false,
+        button: options.button || 0,
+        which: options.which || 1,
+        relatedTarget: options.relatedTarget || null,
+    }
+    var evt;
+    try {
+      // Modern API supported by IE9+
+      evt = new MouseEvent(type, opts);
+    } catch (e) {
+      // Old API still required by PhantomJS.
+      evt = target.ownerDocument.createEvent('MouseEvents');
+      evt.initMouseEvent(type, opts.bubbles, opts.cancelable, opts.view,
+        opts.detail, opts.screenX, opts.screenY, opts.clientX, opts.clientY,
+        opts.ctrlKey, opts.altKey, opts.shiftKey, opts.metaKey, opts.button,
+        opts.relatedTarget);
+    }
+    target.dispatchEvent(evt);
+  }
+  function sequence(delay) {
+    var seq = [],
+        chain = { then: function(fn) { seq.push(fn); return chain; } };
+    function advance() {
+      setTimeout(function() {
+        if (seq.length) {
+          (seq.shift())();
+          advance();
+        }
+      }, delay);
+    }
+    advance();
+    return chain;
+  }
+  asyncTest('Controller: palette block expansion', function() {
+    var editor, states;
+    states = [];
+    document.getElementById('test-main').innerHTML = '';
+    window.editor = editor = new droplet.Editor(document.getElementById('test-main'), {
+      mode: 'coffeescript',
+      palette: [{
+        name: 'Draw',
+        color: 'blue',
+        blocks: [{
+          block: 'pen()',
+          expansion: 'pen red',
+          title: 'ptest'
+        }],
+      }]
+    });
+    simulate('mousedown', '[title=ptest]');
+    simulate('mousemove', '.droplet-drag-cover',
+      { location: '[title=ptest]', dx: 5 });
+    simulate('mousemove', '.droplet-drag-cover',
+      { location: '.droplet-main-scroller' });
+    simulate('mouseup', '.droplet-drag-cover',
+      { location: '.droplet-main-scroller' });
+    equal(editor.getValue().trim(), 'pen red');
+    start();
+  });
+});
+</script>
+</html>


### PR DESCRIPTION
This feature allows a palette block to "expand" into another block when
dragging out of the palette.  The idea is that the block rendered in
the palette can be an abbreviation, and the "real" block might be bigger,
for example, it might include longer arguments etc.

To configure an expansion block, do the following in the palette configuration:

```js
      palette: [{
        name: 'Draw',
        color: 'blue',
        blocks: [{
          block: 'pen()',       // this is what you see in the palette
          expansion: 'pen red', // this is what you get when you drag
          title: 'ptest'
        }],
```

This commit also adds a basic uitest that simulates mouse events
to test the controller, which exercises the expansion feature.