### PR TITLE
add readOnly, textModeAtStart, fix enablePaletteAtStart & setEditorState

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -3854,7 +3854,8 @@ define ['droplet-helper',
 
   Editor::setEditorState = (useBlocks) ->
     if useBlocks
-      @setValue @getAceValue()
+      unless @currentlyUsingBlocks
+        @setValue @getAceValue()
 
       @dropletElement.style.top = '0px'
       if @paletteEnabled
@@ -3873,13 +3874,15 @@ define ['droplet-helper',
         @highlightCanvas.opacity = 1
 
       @resizeBlockMode(); @redrawMain()
-
+      
     else
       paletteVisibleInNewState = @paletteEnabled and @showPaletteInTextMode
 
       oldScrollTop = @aceEditor.session.getScrollTop()
 
-      @setAceValue @getValue()
+      if @currentlyUsingBlocks
+        @setAceValue @getValue()
+
       @aceEditor.resize true
 
       @aceEditor.session.setScrollTop oldScrollTop

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -305,9 +305,9 @@ define ['droplet-helper',
 
       # If we were given an unrecognized mode or asked to start in text mode,
       # flip into text mode here
-      blockMode = @mode? && !@options.textModeAtStart
+      useBlockMode = @mode? && !@options.textModeAtStart
       # Always call @setEditorState to ensure palette is positioned properly
-      @setEditorState blockMode
+      @setEditorState useBlockMode
 
       return this
 

--- a/test/coffee/tests.coffee
+++ b/test/coffee/tests.coffee
@@ -582,6 +582,7 @@ require ['droplet-helper', 'droplet-model', 'droplet-parser', 'droplet-coffee', 
         start()
 
   asyncTest 'Controller: palette events', ->
+    document.getElementById('test-main').innerHTML = ''
     editor = new droplet.Editor document.getElementById('test-main'), {
       mode: 'coffeescript'
       palette: [{


### PR DESCRIPTION
* `getReadOnly` and `setReadOnly` implemented, matching the Ace API (and calling down into Ace for `setReadOnly`)
* `@readOnly` is checked on the droplet side before hit testing, input focus, and key events. The droplet editor can still be scrolled, lines can be highlighted, but no modifications to the content of the document should be possible
* `setEditorState` didn't properly check `@paletteEnabled` and `@showPaletteInTextMode` to position the palette off-screen when necessary. That code only existed in the async `performMeltAnimation` and `performFreezeAnimation`. It now works either way.
* `enablePaletteAtStart` mostly worked if `false` was passed in, but there was a bug in that the palette was never moved off-screen. Solved by always calling `setEditorState` in the constructor.
* `textModeAtStart` is a new option that can be passed to the constructor if you wish to start in text mode