### PR TITLE
Support wildcards for known method names.

### DIFF
--- a/EMBEDDING.md
+++ b/EMBEDDING.md
@@ -145,6 +145,9 @@ language constructs.
 functions: {
     knownFunction: {value: true, color: red}
     myFunction: {value: true, command: true}
+    'Math.random': {value: true}
+    '*.toString': {value: true}
+    '?.fd': { ommand: true}
     setColor: {
       command: true,
       dropdown: {
@@ -179,6 +182,11 @@ categories: {
     errors: {color: '#f00'}
 }
 ```
+
+Functions are recognized by name, and may be bare (global) function names
+or fully-qualified names like 'Math.random'; or they may be wildcard
+method names.  '*.toString' matches any method named toString, and
+'?.fd' matches any method or top-level function named 'fd'.
 
 Each function is associated with a configuration object.  It can specify:
 - value: true if it's a "value" block that should be usable as a value in expressions.

--- a/example/example.coffee
+++ b/example/example.coffee
@@ -120,11 +120,14 @@ require ['droplet'], (droplet) ->
         'write': {}
         'button': {}
         'click': {}
+        'alert': {}
+        'prompt': {}
         'round': {value: true}
         'abs': {value: true}
         'max': {value: true}
         'min': {value: true}
-        'rt': {
+        'Math.random': {value: true}
+        '?.rt': {
           dropdown: {
             0: [
               '30'
@@ -136,7 +139,7 @@ require ['droplet'], (droplet) ->
             ]
           }
         }
-        'lt': {
+        '?.lt': {
           dropdown: {
             0: [
               '30'
@@ -148,7 +151,7 @@ require ['droplet'], (droplet) ->
             ]
           }
         }
-        'pen': {
+        '?.pen': {
           dropdown: {
             0: COLORS = -> [
               {text: 'red', display: '<span style="color:red">red</span>'},
@@ -160,18 +163,18 @@ require ['droplet'], (droplet) ->
             ]
           }
         }
-        'fd': {}
-        'bk': {}
-        'ht': {}
-        'st': {}
-        'pu': {}
-        'pd': {}
-        'label': {}
-        'slide': {}
-        'jump': {}
-        'play': {}
-        'tick': {}
-        'moveto': {
+        '?.fd': {}
+        '?.bk': {}
+        '?.ht': {}
+        '?.st': {}
+        '?.pu': {}
+        '?.pd': {}
+        '?.label': {}
+        '?.slide': {}
+        '?.jump': {}
+        '?.play': {}
+        '?.tick': {}
+        '?.moveto': {
           dropdown: {
             0: MOUSE_THINGS = [
               'lastclick'
@@ -188,7 +191,7 @@ require ['droplet'], (droplet) ->
             ]
           }
         }
-        'turnto': {
+        '?.turnto': {
           dropdown: {
             0: MOUSE_THINGS
           }
@@ -205,7 +208,7 @@ require ['droplet'], (droplet) ->
             ].concat('abcdefghijklmnopqrstuvwxyz'.split('').map((x) -> "'#{x}'"))
           }
         }
-        'wear': {
+        '?.wear': {
           dropdown: {
             0: [
               'pointer'
@@ -215,9 +218,9 @@ require ['droplet'], (droplet) ->
             ]
           }
         }
-        'dot': {dropdown: {0: COLORS}},
-        'box': {dropdown: {0: COLORS}},
-        'speed': {
+        '?.dot': {dropdown: {0: COLORS}},
+        '?.box': {dropdown: {0: COLORS}},
+        '?.speed': {
           dropdown: {
             0: [
               '0.1'

--- a/test/cstest.html
+++ b/test/cstest.html
@@ -125,6 +125,12 @@ function(helper, Coffee, droplet) {
         'Math.log': {
           value: true
         },
+        '*.toString': {
+          value: true
+        },
+        '?.fd': {
+          command: true
+        },
         log: {
           value: true
         },
@@ -135,7 +141,7 @@ function(helper, Coffee, droplet) {
       }
     });
     customSerialization = customCoffee.parse(
-        'console.log Math.log log x.log log').serialize();
+        'console.log Math.log log x.toString log.fd()\nfd()').serialize();
     expectedSerialization = '<segment' +
       '  isLassoSegment="false"' +
       '><block' +
@@ -174,13 +180,32 @@ function(helper, Coffee, droplet) {
       '  precedence="0"' +
       '  handwritten="false"' +
       '  classes="Literal"' +
-      '>x</socket' +
-      '>.log <socket' +
+      '>x</socket>.toString <socket' +
       '  precedence="-1"' +
       '  handwritten="false"' +
-      '  classes="Value"' +
-      '>log</socket' +
-      '></block></socket></block></socket></block></socket></block></segment>';
+      '  classes="Call works-as-method-call"' +
+      '><block' +
+      '  precedence="0"' +
+      '  color="blue"' +
+      '  socketLevel="0"' +
+      '  classes="Call works-as-method-call mostly-block"' +
+      '><socket' +
+      '  precedence="0"' +
+      '  handwritten="false"' +
+      '  classes="Literal"' +
+      '>log</socket>.fd()' +
+      '</block></socket>' +
+      '</block></socket>' +
+      '</block></socket>' +
+      '</block></socket>' +
+      '</block' +
+      '>\n<block' +
+      '  precedence="0"' +
+      '  color="blue"' +
+      '  socketLevel="0"' +
+      '  classes="Call works-as-method-call mostly-block"' +
+      '>fd()</block></segment>';
+    console.log(expectedSerialization.substr(1281));
     strictEqual(
         helper.xmlPrettyPrint(customSerialization),
         helper.xmlPrettyPrint(expectedSerialization),

--- a/test/jstest.html
+++ b/test/jstest.html
@@ -41,8 +41,11 @@ function(helper, JavaScript, droplet) {
         'Math.log': {
           value: true
         },
-        log: {
-          value: true,
+        '*.toString': {
+          value: true
+        },
+        '?.pos': {
+          command: true,
           color: 'red'
         },
         setTimeout: {
@@ -52,11 +55,25 @@ function(helper, JavaScript, droplet) {
       }
     });
     customSerialization = customJS.parse(
-        'return console.log(Math.log(log(x.log(~log))));').serialize();
+        'x.pos(100);\n' +
+        'return console.log(Math.log(log(x.toString(~pos()))));').serialize();
     expectedSerialization =
         '<segment' +
-        '  isLassoSegment="false"' +
-        '><block' +
+        '  isLassoSegment="false">' +
+        '<block' +
+        '  precedence="2"' +
+        '  color="red"' +
+        '  socketLevel="0"' +
+        '  classes="CallExpression mostly-block"><socket' +
+        '  precedence="100"' +
+        '  handwritten="false"' +
+        '  classes=""' +
+        '>x</socket' +
+        '>.pos(<socket' +
+        '  precedence="100"' +
+        '  handwritten="false"' +
+        '  classes="">100</socket>);</block>\n' +
+        '<block' +
         '  precedence="0"' +
         '  color="yellow"' +
         '  socketLevel="0"' +
@@ -85,19 +102,27 @@ function(helper, JavaScript, droplet) {
         '  classes=""' +
         '><block' +
         '  precedence="2"' +
-        '  color="red"' +
+        '  color="blue"' +
         '  socketLevel="0"' +
-        '  classes="CallExpression mostly-value"' +
-        '>log(<socket' +
+        '  classes="CallExpression any-drop"' +
+        '><socket' +
+        '  precedence="100"' +
+        '  handwritten="false"' +
+        '  classes=""' +
+        '>log</socket>(<socket' +
         '  precedence="100"' +
         '  handwritten="false"' +
         '  classes=""' +
         '><block' +
         '  precedence="2"' +
-        '  color="red"' +
+        '  color="green"' +
         '  socketLevel="0"' +
         '  classes="CallExpression mostly-value"' +
-        '>x.log(<socket' +
+        '><socket' +
+        '  precedence="100"' +
+        '  handwritten="false"' +
+        '  classes=""' +
+        '>x</socket>.toString(<socket' +
         '  precedence="100"' +
         '  handwritten="false"' +
         '  classes=""' +
@@ -110,12 +135,18 @@ function(helper, JavaScript, droplet) {
         '  precedence="4"' +
         '  handwritten="false"' +
         '  classes=""' +
-        '>log</socket></block></socket' +
+        '><block' +
+        '  precedence="2"' +
+        '  color="red"' +
+        '  socketLevel="0"' +
+        '  classes="CallExpression mostly-block"' +
+        '>pos()</block></socket></block></socket' +
         '>)</block></socket' +
         '>)</block></socket' +
         '>)</block></socket' +
         '>)</block></socket' +
         '>;</block></segment>';
+    console.log(expectedSerialization.substring(expectedSerialization.indexOf('\n') + 1295));
     strictEqual(
         helper.xmlPrettyPrint(customSerialization),
         helper.xmlPrettyPrint(expectedSerialization),


### PR DESCRIPTION
For example, to recognize a *.toString method on any object,
register a known function as '*.toString'.  The other wildcard
is '?.foo', which matches either 'x.foo()' or top-level 'foo().