### PR TITLE
Allow dropdown options to specify their own `click` handler

### DIFF
--- a/EMBEDDING.md
+++ b/EMBEDDING.md
@@ -157,6 +157,9 @@ functions: {
 
           // Or an object with text and display
           {text: 'red', display: '<span style="color:red">red</span>'}
+
+          // Or a display and a click handler (call the provided callback to set the value)
+          {display: 'click me', click: (callback) -> callback('clicked')}
         ],
 
         // Dropdown element lists can also be generated on the fly by a function

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -2179,14 +2179,21 @@ define ['droplet-helper',
         div.style.fontSize = @fontSize
         div.style.paddingLeft = helper.DROPDOWN_ARROW_WIDTH
 
-        handleClick = (text) =>
+        setText = (text) =>
+          # Attempting to populate the socket after the dropdown has closed should no-op
+          return if @dropdownElement.style.display == 'none'
+
           @populateSocket @textFocus, text
           @hiddenInput.value = text
 
           @redrawMain()
           @hideDropdown()
 
-        div.addEventListener 'mouseup', el.click?.bind(null, handleClick) or handleClick.bind(null, el.text)
+        div.addEventListener 'mouseup', ->
+          if el.click
+            el.click(setText)
+          else
+            setText(el.text)
         @dropdownElement.appendChild div
 
       location = @view.getViewNodeFor(@textFocus).bounds[0]

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -2179,12 +2179,14 @@ define ['droplet-helper',
         div.style.fontSize = @fontSize
         div.style.paddingLeft = helper.DROPDOWN_ARROW_WIDTH
 
-        div.addEventListener 'mouseup', =>
-          @populateSocket @textFocus, el.text
-          @hiddenInput.value = el.text
+        handleClick = (text) =>
+          @populateSocket @textFocus, text
+          @hiddenInput.value = text
 
           @redrawMain()
           @hideDropdown()
+
+        div.addEventListener 'mouseup', el.click?.bind(null, handleClick) or handleClick.bind(null, el.text)
         @dropdownElement.appendChild div
 
       location = @view.getViewNodeFor(@textFocus).bounds[0]


### PR DESCRIPTION
In Applab we'd like to be able to have dropdowns with an "Upload new..." option that opens a modal dialog.  This PR lets dropdown options specify a click handler to be called instead of the default handler.

![screen shot 2015-06-08 at 3 48 18 pm](https://cloud.githubusercontent.com/assets/413693/8047084/d3bb248a-0df5-11e5-9e41-b7cd85c59de1.png)

Sample usage:
```javascript
{display: 'Upload new...', click: (callback) -> promptImage(callback)}
```

The provided handler receives a callback which it can call to populate the socket value (usually after another user interaction).